### PR TITLE
Added Dockerfile from golang and install deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM golang:1.15
 
 RUN apt-get update
-RUN apt-get -y install zip unzip
+RUN apt-get -y install zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
 FROM golang:1.15
 
-RUN apt-get update
-RUN apt-get -y install zip
+RUN apt-get update && apt-get -y install zip && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.15
+
+RUN apt-get update
+RUN apt-get -y install zip unzip

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# docker-go
-Minimal golang base image with a few tools useful in CI jobs
+# Golang
+
+Minimal golang:15 base image with a few tools useful in CI jobs.
+
+Includes:
+
+- zip


### PR DESCRIPTION
Our Go builds currently use the base golang:1.15 image but we want more control over this for CI systems which may expect certain tools to be available.

This installs `zip` this gives us `zip` and `unzip` which are currently needed for our CI.