### PR TITLE
Use alpine 3.14 to fix CVE-2021-36159

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.16-alpine3.14
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 


### PR DESCRIPTION
Snyk has a critical issue on all containers running alpine 3.13, app.snyk.io/vuln/SNYK-ALPINE313-APKTOOLS-1533754

This is fixed in 3.14 so this PR bumps the prebuilt-Dockerfile to that version

[ch2425]