### PR TITLE
Add image for go 1.17

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,5 @@
 #
-# CI pipeline for building the countingup/golang:1.16 Docker image and pushing to Docker Hub
+# CI pipeline for building the countingup/golang Docker image and pushing to Docker Hub
 #
 name: Build and deploy image
 version: v1.0
@@ -16,8 +16,11 @@ blocks:
         - name: countingup-dockerhub
       jobs:
         - name: Build and deploy image
+          matrix:
+            - env_var: GO_VERSION
+              values: ["1.16", "1.17"]
           commands:
             - checkout
-            - docker build -t countingup/golang:1.16 .
+            - docker build --build-arg GO_VERSION -t countingup/golang:${GO_VERSION} .
             - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
-            - docker push countingup/golang:1.16
+            - docker push countingup/golang:${GO_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.16-alpine3.14
+ARG GO_VERSION=1.16
+FROM golang:${GO_VERSION}-alpine3.14
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Golang
 
-[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/countingup/golang.svg)](https://hub.docker.com/r/countingup/golang/builds/) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/golang/1.16)
+[![Build Status](https://countingup.semaphoreci.com/badges/docker-go/branches/master.svg?style=shields)](https://countingup.semaphoreci.com/projects/docker-go) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/golang/1.16?label=1.16+size) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/golang/1.17?label=1.17+size)
 
-Minimal golang:1.16-alpine3.13 base image with a few tools useful in CI jobs.
+Minimal golang:1.16-alpine3.14 / golang:1.17-alpine3.14 base image with a few tools useful in CI jobs.
 
 Includes:
 
@@ -15,4 +15,8 @@ Includes:
 - coreutils
 - curl
 
-When upgrading to a new Go version, don't forget to update the Docker image tag in the Semaphore build pipeline.
+When upgrading to a new Go version:
+ - add the go version to the Semaphore build pipeline
+ - consider whether to bump the alpine base image version
+ - consider whether to remove old go versions (we generally keep the latest 2)
+ - update this README with supported versions


### PR DESCRIPTION
This has been added as a matrix build so that we can continue to rebuild go 1.16 images for security updates for the time being.