### PR TITLE
Rebuild to update base image for security vulns

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ When upgrading to a new Go version:
 ## Changelog
 
  - 2021-11-06 -- Rebuild to update base image for security vulns
+ - 2021-12-13 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
This will update go to 1.17.5 to pull in these [cherry-picked fixes](https://github.com/golang/go/issues?q=milestone%3AGo1.17.5+label%3ACherryPickApproved)