### PR TITLE
Stop building image for golang 1.16

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: GO_VERSION
-              values: ["1.16", "1.17"]
+              values: ["1.17"]
           commands:
             - checkout
             - docker build --build-arg GO_VERSION -t countingup/golang:${GO_VERSION} .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Golang
 
-[![Build Status](https://countingup.semaphoreci.com/badges/docker-go/branches/master.svg?style=shields)](https://countingup.semaphoreci.com/projects/docker-go) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/golang/1.16?label=1.16+size) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/golang/1.17?label=1.17+size)
+[![Build Status](https://countingup.semaphoreci.com/badges/docker-go/branches/master.svg?style=shields)](https://countingup.semaphoreci.com/projects/docker-go) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/golang/1.17?label=1.17+size)
 
-Minimal golang:1.16-alpine3.14 / golang:1.17-alpine3.14 base image with a few tools useful in CI jobs.
+Minimal golang:1.17-alpine3.14 base image with a few tools useful in CI jobs.
 
 Includes:
 
@@ -23,6 +23,7 @@ When upgrading to a new Go version:
 
 ## Changelog
 
+ - 2022-07-18 -- Stop building image for golang 1.16
  - 2022-07-04 -- Rebuild to update base image for security vulns
  - 2022-06-17 -- Rebuild to update base image for security vulns
  - 2022-04-19 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
We are no longer using golang 1.16 and so we can stop maintaining an image for that version.