### PR TITLE
Updating README to force rebuild to resolve security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ When upgrading to a new Go version:
 
 ## Changelog
 
+ - 2022-10-25 -- Rebuild to update base image for security vulns
  - 2022-09-07 -- Rebuild to update base image for security vuln
  - 2022-07-18 -- Stop building image for golang 1.16
  - 2022-07-04 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
Running `snyk` locally returns 0 security vulnerabilities, so updating `README` to force a rebuild.

![image](https://user-images.githubusercontent.com/109339874/197775064-06570c10-0bac-4db4-a1f6-64ab0f567c68.png)
