### PR TITLE
Build image with go1.19 and alpine3.16

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: GO_VERSION
-              values: ["1.17"]
+              values: ["1.19"]
           commands:
             - checkout
             - docker build --build-arg GO_VERSION -t countingup/golang:${GO_VERSION} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM golang:${GO_VERSION}-alpine3.16
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 
-RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip curl libssl1.1 libcrypto1.1
+RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip curl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG GO_VERSION=1.17
-FROM golang:${GO_VERSION}-alpine3.14
+ARG GO_VERSION=1.19
+FROM golang:${GO_VERSION}-alpine3.16
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://countingup.semaphoreci.com/badges/docker-go/branches/master.svg?style=shields)](https://countingup.semaphoreci.com/projects/docker-go) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/golang/1.17?label=1.17+size)
 
-Minimal golang:1.17-alpine3.14 base image with a few tools useful in CI jobs.
+Minimal golang:1.19-alpine3.16 base image with a few tools useful in CI jobs.
 
 Includes:
 
@@ -23,18 +23,13 @@ When upgrading to a new Go version:
 
 ## Changelog
 
- - 2022-10-25 -- Rebuild to update base image for security vulns
- - 2022-09-07 -- Rebuild to update base image for security vuln
+ - 2022-10-27 -- Update to golang 1.19, alpine 3.16. Remove explicit update to libssl and libcrypto
  - 2022-07-18 -- Stop building image for golang 1.16
- - 2022-07-04 -- Rebuild to update base image for security vulns
- - 2022-06-17 -- Rebuild to update base image for security vulns
- - 2022-04-19 -- Rebuild to update base image for security vulns
- - 2022-04-06 -- Rebuild to update base image for security vulns
- - 2022-03-30 -- Rebuild to update base image for security vulns
- - 2022-03-28 -- Rebuild to update base image for security vulns
  - 2022-03-23 -- Explicitly update libssl and libcrypto for security vulns
- - 2022-02-23 -- Rebuild to update base image for security vulns
- - 2022-02-07 -- Rebuild to update base image for security vulns
- - 2022-01-17 -- Rebuild to update base image for security vulns
- - 2021-12-13 -- Rebuild to update base image for security vulns
- - 2021-11-06 -- Rebuild to update base image for security vulns
+
+## Rebuild to update base image for security vulnerabilities
+ - 2022
+   - 25 Oct, 07 Sep, 04 Jul, 17 Jun, 19 Apr, 06 Apr, 30 March, 28 March, 23 Feb, 07 Feb, 17 Jan
+ - 2021
+   - 13 Dec, 06 Nov
+ 


### PR DESCRIPTION
This PR changes the base image (and semaphore selection) so that we are now building our image using go1.19 and alpine3.16.

Additional changes:
- reformatted README.md
- removed update package command for `libssl1.1` and `libcrypto1.1`