### PR TITLE
Rebuild to update sec vuln in `git`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ When upgrading to a new Go version:
 
 ## Changelog
 
+- 2023-04-27 -- Rebuild to update base image for security vulnerability (git)
 - 2023-04-17 -- Rebuild to update base image for security vulnerability (curl)
 - 2023-04-05 -- Rebuild to update base image for security vulnerability (openssl)
 - 2023-03-27 -- Rebuild to update base image for security vulnerability (openssl)


### PR DESCRIPTION
```
Testing cup:go...

Organization:      countingup
Package manager:   apk
Target file:       Dockerfile
Project name:      docker-image|cup
Docker image:      cup:go
Platform:          linux/amd64
Base image:        golang:1.19-alpine3.16
Licenses:          enabled

✓ Tested 43 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
```
