### PR TITLE
Rebuild and upgrade ncurses-libs libcrypto1.1 for security vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM golang:${GO_VERSION}-alpine3.16
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 
-RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip curl
+RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip curl ncurses-libs libcrypto1.1
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ When upgrading to a new Go version:
 
 ## Changelog
 
+|Date|Description|
+|-|-|
 |23-06-01|Explicitly update ncurses-libs and libcrypto1.1 for security vulnerabilities|
 |23-05-22|Rebuild to update base image for security vulnerability (openssl)|
 |23-04-27|Rebuild to update base image for security vulnerability (git)|

--- a/README.md
+++ b/README.md
@@ -23,18 +23,19 @@ When upgrading to a new Go version:
 
 ## Changelog
 
-- 2023-05-22 -- Rebuild to update base image for security vulnerability (openssl)
-- 2023-04-27 -- Rebuild to update base image for security vulnerability (git)
-- 2023-04-17 -- Rebuild to update base image for security vulnerability (curl)
-- 2023-04-05 -- Rebuild to update base image for security vulnerability (openssl)
-- 2023-03-27 -- Rebuild to update base image for security vulnerability (openssl)
-- 2023-02-20 -- Rebuild to update base image for security vulnerability (go)
-- 2023-02-10 -- Rebuild to update base image for security vulnerability (curl)
-- 2023-01-09 -- Rebuild to update base image for security vulnerability (curl)
-- 2022-11-02 -- Rebuild to update base image for security vulnerability (expat)
-- 2022-10-27 -- Update to golang 1.19, alpine 3.16. Remove explicit update to libssl and libcrypto
-- 2022-07-18 -- Stop building image for golang 1.16
-- 2022-03-23 -- Explicitly update libssl and libcrypto for security vulns
+|23-06-01|Explicitly update ncurses-libs and libcrypto1.1 for security vulnerabilities|
+|23-05-22|Rebuild to update base image for security vulnerability (openssl)|
+|23-04-27|Rebuild to update base image for security vulnerability (git)|
+|23-04-17|Rebuild to update base image for security vulnerability (curl)|
+|23-04-05|Rebuild to update base image for security vulnerability (openssl)|
+|23-03-27|Rebuild to update base image for security vulnerability (openssl)|
+|23-02-20|Rebuild to update base image for security vulnerability (go)|
+|23-02-10|Rebuild to update base image for security vulnerability (curl)|
+|23-01-09|Rebuild to update base image for security vulnerability (curl)|
+|22-11-02|Rebuild to update base image for security vulnerability (expat)|
+|22-10-27|Update to golang 1.19, alpine 3.16. Remove explicit update to libssl and libcrypto|
+|22-07-18|Stop building image for golang 1.16|
+|22-03-23|Explicitly update libssl and libcrypto for security vulns|
 
 ## Rebuild to update base image for security vulnerabilities
  - 2022


### PR DESCRIPTION
Resolves:
- [SNYK-ALPINE316-NCURSES-5606597](https://app.snyk.io/vuln/SNYK-ALPINE316-NCURSES-5606597)
- [SNYK-ALPINE316-OPENSSL-5661567](https://app.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-5661567)

>**Note**
>The security changelog updated to use a table


[sc-20472]