### PR TITLE
Rebuild to update nghttp2 vuln

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ When upgrading to a new Go version:
 
 |Date|Description|
 |-|-|
+|23-11-06|Rebuild to update dependencies for security vulnerability (nghttp2)|
 |23-10-13|Rebuild to update dependencies for security vulnerability (libcurl)|
 |23-09-27|Rebuild to update dependencies for security vulnerability (curl)|
 |23-08-02|Rebuild to update dependencies for security vulnerability (pcre2)|


### PR DESCRIPTION
Fixes:
- https://security.snyk.io/vuln/SNYK-ALPINE316-NGHTTP2-6043732

snyk container test --print-deps shows non-vuln version now being used.

```
nghttp2/nghttp2-libs @ 1.47.0-r2
```