### PR TITLE
Rebuild to fix vulnerabilities in libcrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ When upgrading to a new Go version:
 
 |Date|Description|
 |-|-|
+|23-11-21|Rebuild to update dependencies for security vulnerability (libcrypto)|
 |23-11-06|Rebuild to update dependencies for security vulnerability (nghttp2)|
 |23-10-13|Rebuild to update dependencies for security vulnerability (libcurl)|
 |23-09-27|Rebuild to update dependencies for security vulnerability (curl)|


### PR DESCRIPTION
Rebuild to fix [CVE-2023-5678](https://www.cve.org/CVERecord?id=CVE-2023-5678) in libcrypto1.1
