### PR TITLE
Update base image to `golang:1.22-alpine3.18`

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: GO_VERSION
-              values: ["1.19-alpine3.16", "1.22-alpine3.18"]
+              values: ["1.19", "1.22"]
           commands:
             - checkout
             - docker build --build-arg GO_VERSION -t countingup/golang:${GO_VERSION} .

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: GO_VERSION
-              values: ["1.19"]
+              values: ["1.19-alpine3.16", "1.22-alpine3.18"]
           commands:
             - checkout
             - docker build --build-arg GO_VERSION -t countingup/golang:${GO_VERSION} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG GO_VERSION="1.22-alpine3.18"
-FROM golang:${GO_VERSION}
+ARG GO_VERSION="1.22"
+FROM golang:${GO_VERSION}-alpine3.18
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION="1.19-alpine3.16"
+ARG GO_VERSION="1.22-alpine3.18"
 FROM golang:${GO_VERSION}
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG GO_VERSION=1.19
-FROM golang:${GO_VERSION}-alpine3.16
+ARG GO_VERSION="1.19-alpine3.16"
+FROM golang:${GO_VERSION}
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION="1.22"
+ARG GO_VERSION=1.22
 FROM golang:${GO_VERSION}-alpine3.18
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"

--- a/README.md
+++ b/README.md
@@ -23,29 +23,30 @@ When upgrading to a new Go version:
 
 ## Changelog
 
-|Date|Description|
-|-|-|
-|24-02-12|Rebuild to update dependencies for security vulnerability (expat)|
-|24-01-16|Rebuild to update dependencies for security vulnerability (curl)|
-|23-11-21|Rebuild to update dependencies for security vulnerability (libcrypto)|
-|23-11-06|Rebuild to update dependencies for security vulnerability (nghttp2)|
-|23-10-13|Rebuild to update dependencies for security vulnerability (libcurl)|
-|23-09-27|Rebuild to update dependencies for security vulnerability (curl)|
-|23-08-02|Rebuild to update dependencies for security vulnerability (pcre2)|
-|23-07-26|Rebuild to update base image for security vulnerabilities (openssl/nghttp2)|
-|23-06-01|Explicitly update ncurses-libs and libcrypto1.1 for security vulnerabilities|
-|23-05-22|Rebuild to update base image for security vulnerability (openssl)|
-|23-04-27|Rebuild to update base image for security vulnerability (git)|
-|23-04-17|Rebuild to update base image for security vulnerability (curl)|
-|23-04-05|Rebuild to update base image for security vulnerability (openssl)|
-|23-03-27|Rebuild to update base image for security vulnerability (openssl)|
-|23-02-20|Rebuild to update base image for security vulnerability (go)|
-|23-02-10|Rebuild to update base image for security vulnerability (curl)|
-|23-01-09|Rebuild to update base image for security vulnerability (curl)|
-|22-11-02|Rebuild to update base image for security vulnerability (expat)|
-|22-10-27|Update to golang 1.19, alpine 3.16. Remove explicit update to libssl and libcrypto|
-|22-07-18|Stop building image for golang 1.16|
-|22-03-23|Explicitly update libssl and libcrypto for security vulns|
+| Date     | Description                                                                        |
+|----------|------------------------------------------------------------------------------------|
+| 24-04-25 | Update base image to `golang:1.22-alpine3.18`                                      |
+| 24-02-12 | Rebuild to update dependencies for security vulnerability (expat)                  |
+| 24-01-16 | Rebuild to update dependencies for security vulnerability (curl)                   |
+| 23-11-21 | Rebuild to update dependencies for security vulnerability (libcrypto)              |
+| 23-11-06 | Rebuild to update dependencies for security vulnerability (nghttp2)                |
+| 23-10-13 | Rebuild to update dependencies for security vulnerability (libcurl)                |
+| 23-09-27 | Rebuild to update dependencies for security vulnerability (curl)                   |
+| 23-08-02 | Rebuild to update dependencies for security vulnerability (pcre2)                  |
+| 23-07-26 | Rebuild to update base image for security vulnerabilities (openssl/nghttp2)        |
+| 23-06-01 | Explicitly update ncurses-libs and libcrypto1.1 for security vulnerabilities       |
+| 23-05-22 | Rebuild to update base image for security vulnerability (openssl)                  |
+| 23-04-27 | Rebuild to update base image for security vulnerability (git)                      |
+| 23-04-17 | Rebuild to update base image for security vulnerability (curl)                     |
+| 23-04-05 | Rebuild to update base image for security vulnerability (openssl)                  |
+| 23-03-27 | Rebuild to update base image for security vulnerability (openssl)                  |
+| 23-02-20 | Rebuild to update base image for security vulnerability (go)                       |
+| 23-02-10 | Rebuild to update base image for security vulnerability (curl)                     |
+| 23-01-09 | Rebuild to update base image for security vulnerability (curl)                     |
+| 22-11-02 | Rebuild to update base image for security vulnerability (expat)                    |
+| 22-10-27 | Update to golang 1.19, alpine 3.16. Remove explicit update to libssl and libcrypto |
+| 22-07-18 | Stop building image for golang 1.16                                                |
+| 22-03-23 | Explicitly update libssl and libcrypto for security vulns                          |
 
 ## Rebuild to update base image for security vulnerabilities
  - 2022


### PR DESCRIPTION
This PR updates the base image as part of the Golang 1.22 update.

> [!NOTE]  
> We are still building the images for `1.19`. We'll still need these while we update all our services.

> [!WARNING]  
> The `1.19` image will now use `alpine3.16` as to avoid over complicate some code that will be removed soon (1.19 will be phased out pretty quickly)

[sc-22074]
[skip-sc]

