### PR TITLE
Update base image to golang alpine 3.20

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: GO_VERSION
-              values: ["1.19", "1.22"]
+              values: ["1.22"]
           commands:
             - checkout
             - docker build --build-arg GO_VERSION -t countingup/golang:${GO_VERSION} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION=1.22
-FROM golang:${GO_VERSION}-alpine3.18
+FROM golang:${GO_VERSION}-alpine3.20
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 
-RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip curl ncurses-libs libcrypto1.1
+RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip curl ncurses-libs
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ When upgrading to a new Go version:
 
 | Date     | Description                                                                        |
 |----------|------------------------------------------------------------------------------------|
+| 24-07-01 | Update base image to `golang:1.22-alpine3.20`                                      |
 | 24-04-25 | Update base image to `golang:1.22-alpine3.18`                                      |
 | 24-02-12 | Rebuild to update dependencies for security vulnerability (expat)                  |
 | 24-01-16 | Rebuild to update dependencies for security vulnerability (curl)                   |


### PR DESCRIPTION
We no longer use golang 1.19, so stop building this.

Alpine 3.18 tags are no longer being built for newer go patches on the official images, so I've upped the alpine base image to 3.20 to ensure latest security patches are being pulled. This will be goland 1.22.4 at the present time.