### PR TITLE
Use Ubuntu 2404 in CI pipelines

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ version: v1.0
 agent:
   machine:
     type: e2-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 
 blocks:
   - name: Build and deploy image


### PR DESCRIPTION
This replaces usage of ubuntu2004 with ubuntu2404 in CI pipelines.
