### PR TITLE
Remove unused packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM golang:${GO_VERSION}-alpine3.22
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-go"
 
-RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip curl ncurses-libs
+RUN apk add --no-cache --update --upgrade git openssh-client make bash coreutils zip curl ncurses-libs
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Includes:
 - openssh-client
 - make
 - bash
-- lftp
 - coreutils
 - zip
 - curl


### PR DESCRIPTION
`lftp` used to be needed for cache support, but semaphore changed this to a go binary in 2021/22 (https://github.com/semaphoreci/toolbox/pull/350) so it's no longer needed